### PR TITLE
bench PublicKey and Signature parsing and serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hmac-drbg = "0.1"
 sha2 = "0.6"
 digest = "0.6"
 typenum = "1.9"
+arrayref = "0.3"
 
 [dev-dependencies]
 secp256k1-test = "0.7"

--- a/benches/public_key.rs
+++ b/benches/public_key.rs
@@ -1,0 +1,38 @@
+#![feature(test)]
+
+extern crate test;
+extern crate secp256k1;
+extern crate secp256k1_test;
+extern crate rand;
+
+use test::Bencher;
+use secp256k1::PublicKey;
+use secp256k1_test::Secp256k1;
+use rand::thread_rng;
+
+#[bench]
+fn bench_public_key_parse(b: &mut Bencher) {
+    let secp256k1 = Secp256k1::new();
+    let (_, secp_pubkey) = secp256k1.generate_keypair(&mut thread_rng()).unwrap();
+    let pubkey_arr = secp_pubkey.serialize_vec(&secp256k1, false);
+    assert!(pubkey_arr.len() == 65);
+    let mut pubkey_a = [0u8; 65];
+    pubkey_a[0..65].copy_from_slice(&pubkey_arr[0..65]);
+    b.iter(|| {
+        let _pubkey = PublicKey::parse(&pubkey_a).unwrap();
+    });
+}
+
+#[bench]
+fn bench_public_key_serialize(b: &mut Bencher) {
+    let secp256k1 = Secp256k1::new();
+    let (_, secp_pubkey) = secp256k1.generate_keypair(&mut thread_rng()).unwrap();
+    let pubkey_arr = secp_pubkey.serialize_vec(&secp256k1, false);
+    assert!(pubkey_arr.len() == 65);
+    let mut pubkey_a = [0u8; 65];
+    pubkey_a[0..65].copy_from_slice(&pubkey_arr[0..65]);
+    let pubkey = PublicKey::parse(&pubkey_a).unwrap();
+    b.iter(|| {
+        let _serialized = pubkey.serialize();
+    });
+}

--- a/benches/signature.rs
+++ b/benches/signature.rs
@@ -1,0 +1,46 @@
+#![feature(test)]
+
+extern crate test;
+extern crate secp256k1;
+extern crate secp256k1_test;
+extern crate rand;
+
+use test::Bencher;
+use secp256k1::Signature;
+use secp256k1_test::{Secp256k1, Message as SecpMessage};
+use rand::thread_rng;
+
+#[bench]
+fn bench_signature_parse(b: &mut Bencher) {
+    let secp256k1 = Secp256k1::new();
+    let message_arr = [5u8; 32];
+    let (privkey, _) = secp256k1.generate_keypair(&mut thread_rng()).unwrap();
+    let message = SecpMessage::from_slice(&message_arr).unwrap();
+    let signature = secp256k1.sign(&message, &privkey).unwrap();
+    let signature_arr = signature.serialize_compact(&secp256k1);
+    assert!(signature_arr.len() == 64);
+    let mut signature_a = [0u8; 64];
+    signature_a.copy_from_slice(&signature_arr[0..64]);
+
+    b.iter(|| {
+        let _signature = Signature::parse(&signature_a);
+    });
+}
+
+#[bench]
+fn bench_signature_serialize(b: &mut Bencher) {
+    let secp256k1 = Secp256k1::new();
+    let message_arr = [5u8; 32];
+    let (privkey, _) = secp256k1.generate_keypair(&mut thread_rng()).unwrap();
+    let message = SecpMessage::from_slice(&message_arr).unwrap();
+    let signature = secp256k1.sign(&message, &privkey).unwrap();
+    let signature_arr = signature.serialize_compact(&secp256k1);
+    assert!(signature_arr.len() == 64);
+    let mut signature_a = [0u8; 64];
+    signature_a.copy_from_slice(&signature_arr[0..64]);
+    let signature = Signature::parse(&signature_a);
+
+    b.iter(|| {
+        let _serialized = signature.serialize();
+    });
+}

--- a/src/field.rs
+++ b/src/field.rs
@@ -381,13 +381,9 @@ impl Field {
         return true;
     }
 
-    /// Convert a field element to a 32-byte big endian
-    /// value. Requires the input to be normalized.
-    pub fn b32(&self) -> [u8; 32] {
+    pub fn fill_b32(&self, r: &mut [u8; 32]) {
         debug_assert!(self.normalized);
         debug_assert!(self.verify());
-
-        let mut r = [0u8; 32];
 
         r[0] = ((self.n[9] >> 14) & 0xff) as u8;
         r[1] = ((self.n[9] >> 6) & 0xff) as u8;
@@ -421,7 +417,13 @@ impl Field {
         r[29] = ((self.n[0] >> 16) & 0xff) as u8;
         r[30] = ((self.n[0] >> 8) & 0xff) as u8;
         r[31] = (self.n[0] & 0xff) as u8;
+    }
 
+    /// Convert a field element to a 32-byte big endian
+    /// value. Requires the input to be normalized.
+    pub fn b32(&self) -> [u8; 32] {
+        let mut r = [0u8; 32];
+        self.fill_b32(&mut r);
         r
     }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -168,6 +168,12 @@ impl Scalar {
     /// Convert a scalar to a byte array.
     pub fn b32(&self) -> [u8; 32] {
         let mut bin = [0u8; 32];
+        self.fill_b32(&mut bin);
+        bin
+    }
+
+    /// Convert a scalar to a byte array.
+    pub fn fill_b32(&self, bin: &mut [u8; 32]) {
         bin[0] = (self.0[7] >> 24) as u8; bin[1] = (self.0[7] >> 16) as u8; bin[2] = (self.0[7] >> 8) as u8; bin[3] = (self.0[7]) as u8;
         bin[4] = (self.0[6] >> 24) as u8; bin[5] = (self.0[6] >> 16) as u8; bin[6] = (self.0[6] >> 8) as u8; bin[7] = (self.0[6]) as u8;
         bin[8] = (self.0[5] >> 24) as u8; bin[9] = (self.0[5] >> 16) as u8; bin[10] = (self.0[5] >> 8) as u8; bin[11] = (self.0[5]) as u8;
@@ -176,7 +182,6 @@ impl Scalar {
         bin[20] = (self.0[2] >> 24) as u8; bin[21] = (self.0[2] >> 16) as u8; bin[22] = (self.0[2] >> 8) as u8; bin[23] = (self.0[2]) as u8;
         bin[24] = (self.0[1] >> 24) as u8; bin[25] = (self.0[1] >> 16) as u8; bin[26] = (self.0[1] >> 8) as u8; bin[27] = (self.0[1]) as u8;
         bin[28] = (self.0[0] >> 24) as u8; bin[29] = (self.0[0] >> 16) as u8; bin[30] = (self.0[0] >> 8) as u8; bin[31] = (self.0[0]) as u8;
-        bin
     }
 
     /// Check whether a scalar equals zero.


### PR DESCRIPTION
before:

```
test bench_public_key_parse ... bench:         320 ns/iter (+/- 96)
test bench_public_key_serialize ... bench:         150 ns/iter (+/- 7)
test bench_signature_parse     ... bench:         135 ns/iter (+/- 9)
test bench_signature_serialize ... bench:         144 ns/iter (+/- 24)
```

after:

```
test bench_public_key_parse     ... bench:         206 ns/iter (+/- 20)
test bench_public_key_serialize ... bench:          45 ns/iter (+/- 4)
test bench_signature_parse     ... bench:          22 ns/iter (+/- 3)
test bench_signature_serialize ... bench:          29 ns/iter (+/- 5)
```