### PR TITLE
Added Drop to SharedSecret and SecretKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,9 @@ impl SharedSecret {
     }
 
     pub fn clear(&mut self) {
-        self.0 = [0u8; 32];
+        unsafe {
+            core::ptr::write_volatile(&mut self.0, [0u8; 32]);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,12 @@ impl Default for SecretKey {
     }
 }
 
+impl Into<Scalar> for SecretKey {
+    fn into(self) -> Scalar {
+        self.0.clone()
+    }
+}
+
 impl Drop for SecretKey {
     fn drop(&mut self) {
         self.0.clear();
@@ -574,11 +580,6 @@ impl SharedSecret {
         Ok(SharedSecret(inner))
     }
 
-    pub fn clear(&mut self) {
-        unsafe {
-            core::ptr::write_volatile(&mut self.0, [0u8; 32]);
-        }
-    }
 }
 
 impl AsRef<[u8]> for SharedSecret {
@@ -589,7 +590,9 @@ impl AsRef<[u8]> for SharedSecret {
 
 impl Drop for SharedSecret {
     fn drop(&mut self) {
-        self.clear();
+         unsafe {
+            core::ptr::write_volatile(&mut self.0, [0u8; 32]);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,9 +366,9 @@ impl Default for SecretKey {
     }
 }
 
-impl Into<Scalar> for SecretKey {
-    fn into(self) -> Scalar {
-        self.0
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.0.clear();
     }
 }
 
@@ -573,11 +573,21 @@ impl SharedSecret {
 
         Ok(SharedSecret(inner))
     }
+
+    pub fn clear(&mut self) {
+        self.0 = [0u8; 32];
+    }
 }
 
 impl AsRef<[u8]> for SharedSecret {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        self.clear();
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -31,7 +31,9 @@ pub struct Scalar(pub [u32; 8]);
 impl Scalar {
     /// Clear a scalar to prevent the leak of sensitive data.
     pub fn clear(&mut self) {
-        self.0 = [0u32; 8];
+        unsafe {
+            core::ptr::write_volatile(&mut self.0, [0u32; 8]);
+        }
     }
 
     /// Set a scalar to an unsigned integer.


### PR DESCRIPTION
- I added the Drop trait to SecretKey and SharedSecret which calls `clear()`, 
- I replaced the clear function with `write_volatile` to prevent the compiler from optimizing it out.